### PR TITLE
Make `CounterWidget.tsx` testable and add some tests

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/__tests__/components/CounterWidget.test.tsx
+++ b/src/__tests__/components/CounterWidget.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CounterWidget from "../../components/CounterWidget";
+
+describe("initialization", () => {
+  describe("if the initial count is omitted", () => {
+    it("should display 0 as the count and no beads", () => {
+      render(<CounterWidget />);
+
+      expect(screen.getByTestId("count")).toHaveTextContent("0");
+      expect(screen.queryAllByTestId("bead")).toEqual([]);
+    });
+  });
+
+  describe("if the initial count is specified as 1", () => {
+    it("should display 1 as the count and a sing bead", () => {
+      render(<CounterWidget initialCount={1} />);
+
+      expect(screen.getByTestId("count")).toHaveTextContent("1");
+      expect(screen.queryAllByTestId("bead")).toHaveLength(1);
+    });
+  });
+});
+
+describe("buttons", () => {
+  describe("if the button labeled with '-1' is clicked", () => {
+    it("should display the count decremented by 1 and the same number of beads", () => {
+      render(<CounterWidget />);
+      const count = screen.getByTestId("count");
+
+      expect(count).toHaveTextContent("0");
+      expect(screen.queryAllByAltText("bead")).toHaveLength(0);
+
+      userEvent.click(screen.getByTestId("decrement"));
+
+      expect(count).toHaveTextContent("-1");
+      expect(screen.queryAllByAltText("bead")).toHaveLength(0);
+    });
+  });
+
+  describe("if the button labeled with '+1' is clicked", () => {
+    it("should display the count incremented by 1 and the same number of beads", () => {
+      render(<CounterWidget />);
+      const count = screen.getByTestId("count");
+
+      expect(count).toHaveTextContent("0");
+      expect(screen.queryAllByTestId("bead")).toHaveLength(0);
+
+      userEvent.click(screen.getByTestId("increment"));
+
+      expect(count).toHaveTextContent("1");
+      expect(screen.queryAllByTestId("bead")).toHaveLength(1);
+    });
+  });
+
+  describe("if the button labeled with '+10' is clicked", () => {
+    it("should display the count incremented by 10 and the same number of beads", () => {
+      render(<CounterWidget />);
+      const count = screen.getByTestId("count");
+
+      expect(count).toHaveTextContent("0");
+      expect(screen.queryAllByTestId("bead")).toHaveLength(0);
+
+      userEvent.click(screen.getByTestId("add"));
+
+      expect(count).toHaveTextContent("10");
+      expect(screen.queryAllByTestId("bead")).toHaveLength(10);
+    });
+  });
+
+  describe("if all the buttons are clicked one by one", () => {
+    it("should display the count and the number of beads correctly", () => {
+      render(<CounterWidget initialCount={3} />);
+      const count = screen.getByTestId("count");
+
+      expect(count).toHaveTextContent("3");
+      expect(screen.queryAllByTestId("bead")).toHaveLength(3);
+
+      userEvent.click(screen.getByTestId("increment"));
+      expect(count).toHaveTextContent("4");
+      expect(screen.queryAllByTestId("bead")).toHaveLength(4);
+
+      userEvent.click(screen.getByTestId("decrement"));
+      expect(count).toHaveTextContent("3");
+      expect(screen.queryAllByTestId("bead")).toHaveLength(3);
+
+      userEvent.click(screen.getByTestId("add"));
+      expect(count).toHaveTextContent("13");
+      expect(screen.queryAllByTestId("bead")).toHaveLength(13);
+    });
+  });
+});

--- a/src/__tests__/ducks/counterSlice.test.ts
+++ b/src/__tests__/ducks/counterSlice.test.ts
@@ -1,0 +1,31 @@
+import counterSlice from "../../ducks/counterSlice";
+
+const {
+  reducer,
+  actions: { added, decremented, incremented },
+} = counterSlice;
+let currentState: { count: number };
+
+beforeEach(() => {
+  currentState = { count: 0 };
+});
+
+describe("reducer", () => {
+  describe("if action type is 'added'", () => {
+    it("should return the count incremented by a number in the parameter", () => {
+      expect(reducer(currentState, added(2))).toEqual({ count: 2 });
+    });
+  });
+
+  describe("if action type is 'decremented'", () => {
+    it("should return the count decremented by 1", () => {
+      expect(reducer(currentState, decremented())).toEqual({ count: -1 });
+    });
+  });
+
+  describe("if action type is 'incremented'", () => {
+    it("should return the count incremented by 1", () => {
+      expect(reducer(currentState, incremented())).toEqual({ count: 1 });
+    });
+  });
+});

--- a/src/components/ColorfulBeads.tsx
+++ b/src/components/ColorfulBeads.tsx
@@ -28,7 +28,12 @@ type Props = { count: number };
 const ColorfulBeads = ({ count }: Props) => (
   <SemanticContainer className="beads-box">
     {range(count).map((n: number) => (
-      <Label circular color={colors[n % colors.length]} key={n} />
+      <Label
+        circular
+        color={colors[n % colors.length]}
+        key={n}
+        data-testid="bead"
+      />
     ))}
   </SemanticContainer>
 );

--- a/src/components/CounterBoard.tsx
+++ b/src/components/CounterBoard.tsx
@@ -19,19 +19,24 @@ const CounterBoard = ({
   <Card>
     <Statistic className="number-board">
       <Statistic.Label>count</Statistic.Label>
-      <Statistic.Value>{count}</Statistic.Value>
+      <Statistic.Value data-testid="count">{count}</Statistic.Value>
     </Statistic>
     <Card.Content>
       <div className="ui two buttons">
-        <Button color="red" onClick={decrement}>
+        <Button color="red" onClick={decrement} data-testid="decrement">
           -1
         </Button>
-        <Button color="green" onClick={increment}>
+        <Button color="green" onClick={increment} data-testid="increment">
           +1
         </Button>
       </div>
       <div className="fluid-button">
-        <Button fluid color="grey" onClick={() => add(BULK_UNIT)}>
+        <Button
+          fluid
+          color="grey"
+          onClick={() => add(BULK_UNIT)}
+          data-testid="add"
+        >
           +{BULK_UNIT}
         </Button>
       </div>

--- a/src/components/CounterWidget.tsx
+++ b/src/components/CounterWidget.tsx
@@ -1,13 +1,10 @@
-import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { useReducer } from "react";
 import ColorfulBeads from "./ColorfulBeads";
 import type { CounterBoardProps } from "./CounterBoard";
+import counterSlice from "../ducks/counterSlice";
 import CounterBoard from "./CounterBoard";
 
 type ContainerProps = { initialCount?: number };
-type CounterState = { count: number };
-
-const initialState: CounterState = { count: 0 };
 
 const Component = ({
   count = 0,
@@ -21,32 +18,16 @@ const Component = ({
   </>
 );
 
-export const counterSlice = createSlice({
-  name: "counter",
-  initialState,
-  reducers: {
-    added: (state: CounterState, action: PayloadAction<number>) => ({
-      ...state,
-      count: state.count + action.payload,
-    }),
-    decremented: (state: CounterState) => ({
-      ...state,
-      count: state.count - 1,
-    }),
-    incremented: (state: CounterState) => ({
-      ...state,
-      count: state.count + 1,
-    }),
-  },
-});
-
 const Container = ({ initialCount = 0 }: ContainerProps) => {
+  const {
+    reducer,
+    actions: { added, decremented, incremented },
+  } = counterSlice;
   const [state, dispatch] = useReducer(
-    counterSlice.reducer,
+    reducer,
     initialCount,
     (count: number) => ({ count })
   );
-  const { added, decremented, incremented } = counterSlice.actions;
 
   return (
     <Component

--- a/src/ducks/counterSlice.ts
+++ b/src/ducks/counterSlice.ts
@@ -1,0 +1,19 @@
+import { PayloadAction } from "@reduxjs/toolkit";
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = { count: 0 };
+
+const counterSlice = createSlice({
+  name: "counter",
+  initialState,
+  reducers: {
+    added: (state, action: PayloadAction<number>) => ({
+      ...state,
+      count: state.count + action.payload,
+    }),
+    decremented: (state) => ({ ...state, count: state.count - 1 }),
+    incremented: (state) => ({ ...state, count: state.count + 1 }),
+  },
+});
+
+export default counterSlice;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom/client";
 import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
 import reportWebVitals from "./reportWebVitals";
-import { counterSlice } from "./components/CounterWidget";
+import counterSlice from "./ducks/counterSlice";
 import App from "./App";
 import "./index.css";
 import "semantic-ui-css/semantic.min.css";


### PR DESCRIPTION
## Description

Now, `CounterWidget.tsx` has counter logic using `createSlice` API. I think it's better that logic is moved to an another file named `countrSlice.ts` to make it easy to write tests.

refs: #3 

## Checklists

- [x] Move the logic in `CounterWidget.tsx` to `counterSlice.ts`
- [x] Add tests for a reducer in `counterSlice.ts`
- [x] Add tests for `CounterWidget.tsx`